### PR TITLE
Remove redundant entry points

### DIFF
--- a/lib/screens/auth/email_page.dart
+++ b/lib/screens/auth/email_page.dart
@@ -11,22 +11,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'password_page.dart';
 
-void main() {
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: EmailScreen(),
-    );
-  }
-}
-
 class LowerCaseTextFormatter extends TextInputFormatter {
   @override
   TextEditingValue formatEditUpdate(

--- a/lib/screens/auth/login_page.dart
+++ b/lib/screens/auth/login_page.dart
@@ -14,22 +14,6 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'home_page.dart';
 import '../../manage/api_manage.dart';
 
-void main() {
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: LoginPage(),
-    );
-  }
-}
-
 class LowerCaseTextFormatter extends TextInputFormatter {
   @override
   TextEditingValue formatEditUpdate(

--- a/lib/screens/auth/password_page.dart
+++ b/lib/screens/auth/password_page.dart
@@ -2,22 +2,6 @@ import 'package:flutter/material.dart';
 import 'confirmation_page.dart';
 import '../../manage/api_manage.dart';
 
-void main() {
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: PasswordScreen(email: 'your.name@epitech.eu'),
-    );
-  }
-}
-
 class PasswordScreen extends StatefulWidget {
   final String email;
 

--- a/lib/screens/listen_page.dart
+++ b/lib/screens/listen_page.dart
@@ -22,10 +22,6 @@ import '../manage/cache_manage.dart';
 import 'library_page.dart';
 import 'package:flutter/cupertino.dart';
 
-void main() {
-  runApp(const MyApp());
-}
-
 class GenreTile extends StatelessWidget {
   final String name;
   final Color overlayColor;
@@ -73,32 +69,6 @@ class GenreTile extends StatelessWidget {
   }
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        brightness: Brightness.dark,
-        primaryColor: Colors.black,
-        scaffoldBackgroundColor: Colors.black,
-        textTheme: const TextTheme(
-          bodyLarge: TextStyle(color: Colors.white),
-          bodyMedium: TextStyle(color: Colors.white),
-          titleLarge: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-        ),
-        bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-          backgroundColor: Colors.black,
-          selectedItemColor: Colors.white,
-          unselectedItemColor: Colors.white70,
-        ),
-      ),
-      home: MusicAppHomePage(songManager: SongManager()),
-    );
-  }
-}
 
 class MusicAppHomePage extends StatefulWidget {
   final SongManager songManager;


### PR DESCRIPTION
## Summary
- drop extra `main()` calls and `MyApp` widgets from auth and listen screens
- keep the only entry point in `lib/main.dart`

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852fbd8cee48325942a9a95b0f9dada