### PR TITLE
Replace prints with build-mode logger

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/foundation.dart';
+
+/// Simple logger that only outputs messages in debug mode.
+class AppLogger {
+  AppLogger._();
+
+  static void log(String message) {
+    if (kDebugMode) {
+      debugPrint(message);
+    }
+  }
+}

--- a/lib/manage/api_manage.dart
+++ b/lib/manage/api_manage.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import '../logger.dart';
 
 class MusicApiService {
   static String get baseUrl => dotenv.env['BASE_URL'] ?? 'http://192.168.1.53:8000';
@@ -229,7 +230,7 @@ class MusicApiService {
   }
 
   Future<List<Map<String, dynamic>>> getSearch(String cookie, String name) async {
-    debugPrint("hello: $name");
+    AppLogger.log("hello: $name");
     try {
       final response = await http.post(
         Uri.parse('$baseUrl/music/search'),
@@ -248,7 +249,7 @@ class MusicApiService {
   }
 
   Future<Map<String, dynamic>> createLike(String songId, String token) async {
-    debugPrint("hello: $songId/$token");
+    AppLogger.log("hello: $songId/$token");
     try {
       final response = await http.post(
         Uri.parse('$baseUrl/music/liked'),
@@ -274,7 +275,7 @@ class MusicApiService {
       );
       if (response.statusCode == 200) {
         final rep = json.decode(response.body);
-        debugPrint("rep: $rep");
+        AppLogger.log("rep: $rep");
         if (rep["liked"] == "true") {
           return true;
         } else {
@@ -310,7 +311,7 @@ class MusicApiService {
         Uri.parse('$baseUrl/music/count-liked'),
         headers: {'Content-Type': 'application/json', 'token': token},
       );
-      debugPrint("response: ${response.body}");
+      AppLogger.log("response: ${response.body}");
       if (response.statusCode == 200) {
         return json.decode(response.body)["count"].toString();
       } else {

--- a/lib/manage/song_manage.dart
+++ b/lib/manage/song_manage.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'api_manage.dart';
+import '../logger.dart';
 
 class SongManager {
   final AudioPlayer _audioPlayer = AudioPlayer();
@@ -91,7 +92,7 @@ class SongManager {
         instant: true,
       );
     } else {
-      debugPrint('No more songs in the queue.');
+      AppLogger.log('No more songs in the queue.');
     }
   }
 
@@ -127,7 +128,7 @@ class SongManager {
         songId: element['song_id'],
       );
       } else {
-      debugPrint('Skipping song with missing information: $element');
+      AppLogger.log('Skipping song with missing information: $element');
       }
     }
     if (_queue.isNotEmpty) {
@@ -140,7 +141,7 @@ class SongManager {
       songId: _queue[_queueIndex]['songId'],
       );
     } else {
-      debugPrint('No valid songs to play.');
+      AppLogger.log('No valid songs to play.');
     }
   }
 
@@ -153,7 +154,7 @@ class SongManager {
     required String songId,
     bool instant = true,
   }) async {
-    debugPrint('Toggling song: $name/$description/$songUrl/$pictureUrl/$artist/$songId');
+    AppLogger.log('Toggling song: $name/$description/$songUrl/$pictureUrl/$artist/$songId');
     try {
       if (_currentSongUrl == songUrl) {
         if (_isPlaying) {
@@ -217,7 +218,7 @@ class SongManager {
         }
       }
     } catch (e) {
-      debugPrint('Error playing song: $e');
+      AppLogger.log('Error playing song: $e');
       _isPlaying = false;
     }
   }

--- a/lib/manage/widget_manage.dart
+++ b/lib/manage/widget_manage.dart
@@ -10,6 +10,7 @@
 import 'package:epico/manage/api_manage.dart';
 import 'package:flutter/material.dart';
 import 'package:audioplayers/audioplayers.dart';
+import '../logger.dart';
 import 'song_manage.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
@@ -353,7 +354,7 @@ class AudioPlayerWidgetState extends State<AudioPlayerWidget> {
                           // Toggle the notifier value which will trigger a rebuild
                           bool liked = await MusicApiService().isLike(widget.songManager.getSongState()["songId"], authCookie!);
                           _isLikedNotifier.value = liked;
-                          debugPrint("isLiked2: ${_isLikedNotifier.value}");
+                          AppLogger.log('isLiked2: ${_isLikedNotifier.value}');
                         },
                       );
                     },

--- a/lib/screens/auth/home_page.dart
+++ b/lib/screens/auth/home_page.dart
@@ -16,6 +16,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:epico/manage/song_manage.dart';
 import 'package:epico/manage/api_manage.dart';
 import 'package:epico/manage/cache_manage.dart';
+import '../../logger.dart';
 
 class HomePage extends StatefulWidget {
   @override
@@ -49,10 +50,10 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
           MaterialPageRoute(builder: (context) => MusicAppHomePage(songManager: songManager)),
         );
       } catch (e) {
-        debugPrint('Error fetching user info: $e');
+        AppLogger.log('Error fetching user info: $e');
       }
     } else {
-      debugPrint('No auth token found');
+      AppLogger.log('No auth token found');
     }
   }
 

--- a/lib/screens/auth/password_page.dart
+++ b/lib/screens/auth/password_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'confirmation_page.dart';
 import '../../manage/api_manage.dart';
+import '../../logger.dart';
 
 class PasswordScreen extends StatefulWidget {
   final String email;
@@ -24,7 +25,7 @@ class _PasswordScreenState extends State<PasswordScreen> {
   void initState() {
     super.initState();
     _passwordController.addListener(_validatePassword);
-    print("Email from previous page: ${widget.email}"); // Example usage
+    AppLogger.log("Email from previous page: ${widget.email}"); // Example usage
   }
 
   @override

--- a/lib/screens/library_page.dart
+++ b/lib/screens/library_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../manage/song_manage.dart';
 import '../manage/api_manage.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import '../logger.dart';
 
 class LibraryPage extends StatefulWidget {
   final SongManager songManager;
@@ -43,7 +44,7 @@ class _LibraryPageState extends State<LibraryPage> {
         setState(() {
           _isLoading = false;
         });
-        debugPrint('Error loading recently played tracks: $e');
+        AppLogger.log('Error loading recently played tracks: $e');
       }
     } else {
       setState(() {
@@ -60,7 +61,7 @@ class _LibraryPageState extends State<LibraryPage> {
           _likedCount = count;
         });
       } catch (e) {
-        debugPrint('Error loading liked count: $e');
+        AppLogger.log('Error loading liked count: $e');
       }
     }
   }
@@ -73,7 +74,7 @@ class _LibraryPageState extends State<LibraryPage> {
           _artistCount = count;
         });
       } catch (e) {
-        debugPrint('Error loading artist count: $e');
+        AppLogger.log('Error loading artist count: $e');
       }
     }
   }

--- a/lib/screens/listen_page.dart
+++ b/lib/screens/listen_page.dart
@@ -21,6 +21,7 @@ import 'package:async/async.dart';
 import '../manage/cache_manage.dart';
 import 'library_page.dart';
 import 'package:flutter/cupertino.dart';
+import '../logger.dart';
 
 class GenreTile extends StatelessWidget {
   final String name;
@@ -254,7 +255,7 @@ class _MusicAppHomePageState extends State<MusicAppHomePage> {
               ),
             );
           } else {
-            print('snapshot.data: ${snapshot.data}');
+            AppLogger.log('snapshot.data: ${snapshot.data}');
             return Text(
               "Hi ${extractFirstNameFromEmail(snapshot.data ?? 'default.name@epitech.eu')},",
               style: const TextStyle(
@@ -333,7 +334,7 @@ class _MusicAppHomePageState extends State<MusicAppHomePage> {
                         itemCount: snapshot.data!.length,
                         itemBuilder: (context, index) {
                           final track = snapshot.data![index];
-                          debugPrint('track: $track');
+                          AppLogger.log('track: $track');
                           return _buildAlbumCard(
                             track['title'] ?? 'Unknown Title',
                             track['cover'] ?? 'assets/caca.jpg',
@@ -1085,9 +1086,9 @@ class _MusicAppHomePageState extends State<MusicAppHomePage> {
                     onChanged: (query) async {
                       _lastQuery = query;
                       if (query.isNotEmpty) {
-                        debugPrint(query);
+                        AppLogger.log(query);
                         var results = await MusicApiService().getSearch(authCookie!, query);
-                        debugPrint(results.toString());
+                        AppLogger.log(results.toString());
                         setState(() {
                           _searchResults = results;
                         });


### PR DESCRIPTION
## Summary
- add `AppLogger` to gate logs behind `kDebugMode`
- use `AppLogger` instead of `print`/`debugPrint`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530215d7348325a3bfe88d4f0de0e2