### PR TITLE
Update search results to show artists and albums

### DIFF
--- a/lib/manage/api_manage.dart
+++ b/lib/manage/api_manage.dart
@@ -227,22 +227,21 @@ class MusicApiService {
     }
   }
 
-  Future<List<Map<String, dynamic>>> getSearch(String cookie, String name) async {
+  Future<Map<String, dynamic>> getSearch(String cookie, String name) async {
     debugPrint("hello: $name");
     try {
       final response = await http.post(
         Uri.parse('$baseUrl/music/search'),
         headers: {'Content-Type': 'application/json', 'token': cookie},
         body: json.encode({'name': name}),
-        );
-      if (response.statusCode == 200) {
-        List<dynamic> data = json.decode(response.body);
-        return data.map((item) => item as Map<String, dynamic>).toList();
-      } else {
-        throw Exception('Failed to load from follow tracks: ${response.statusCode}');
-      }
+      );
+      debugPrint("Search response: ${response.body}");
+      
+      // Retourner l'objet complet au lieu d'une liste
+      Map<String, dynamic> data = json.decode(response.body);
+      return data;
     } catch (e) {
-      throw Exception('Error fetching from follow tracks: $e');
+      throw Exception('Error fetching search results: $e');
     }
   }
 


### PR DESCRIPTION
## Summary
- support artists and albums when displaying search results
- add helpers to build artist and album search widgets

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546e8fd47483258ad2cc5d8137a095