### PR TITLE
[~] build-and-release.yml: Refactor build-and-release workflow to improve asset naming and streamline Linux dependency installation

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -37,7 +37,8 @@ jobs:
               sudo apt-get update
               sudo apt-get install -y libgtk-3-dev libunwind-dev pkg-config clang cmake ninja-build \
                 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-                gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly
+                gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+                libsecret-1-dev
             build_cmd: flutter build linux --release
             artifact: build/linux/x64/release/bundle/epico
             asset: Epico_linux


### PR DESCRIPTION
This pull request modifies the GitHub Actions workflow configuration for building and releasing platform-specific artifacts. The changes primarily involve renaming artifacts for consistency, updating file paths, and enhancing the setup process for Linux dependencies.

### Artifact naming and path updates:
* Updated artifact names for Android, Windows, macOS, and Linux builds to follow a consistent naming convention (`Epico-android.apk`, `Epico_windows.exe`, `Epico-macos.zip`, `Epico_linux`). Adjusted file paths to match the new naming scheme. (`[.github/workflows/build-and-release.ymlL17-R44](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL17-R44)`)

### Linux setup improvements:
* Enhanced the Linux setup process by adding additional dependencies (`libunwind-dev`, `pkg-config`, `clang`, `cmake`, `ninja-build`, and various `gstreamer` packages) to ensure compatibility and improve build reliability. (`[.github/workflows/build-and-release.ymlL17-R44](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL17-R44)`)

### Workflow step renaming:
* Renamed the step for installing dependencies from "Install Linux deps" to "Install system deps" for broader applicability and clarity. (`[.github/workflows/build-and-release.ymlL60-R57](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL60-R57)`)