### PR TITLE
[~]: Refactor API data handling in MusicApiService and update song URL retrieval in AlbumInfoPage; fixe like status api fetch

### DIFF
--- a/lib/manage/api_manage.dart
+++ b/lib/manage/api_manage.dart
@@ -383,12 +383,8 @@ class MusicApiService {
       );
       if (response.statusCode == 200) {
         dynamic data = json.decode(response.body);
-        debugPrint('Raw album tracks data: ${data.toString()}');
         
-        // Vérifier si data est une Map ou une List
         if (data is Map<String, dynamic>) {
-          // Si c'est une Map, chercher une clé qui contient les pistes
-          // Les clés possibles peuvent être 'tracks', 'data', 'songs', etc.
           if (data.containsKey('tracks') && data['tracks'] is List) {
             List<dynamic> tracks = data['tracks'];
             return tracks.map((item) => item as Map<String, dynamic>).toList();
@@ -399,7 +395,6 @@ class MusicApiService {
             List<dynamic> tracks = data['songs'];
             return tracks.map((item) => item as Map<String, dynamic>).toList();
           } else {
-            // Si aucune clé connue n'est trouvée, convertir les valeurs de la Map en List
             List<Map<String, dynamic>> tracks = [];
             data.forEach((key, value) {
               if (value is Map<String, dynamic>) {
@@ -415,7 +410,6 @@ class MusicApiService {
             return tracks;
           }
         } else if (data is List) {
-          // Si c'est déjà une List, la traiter normalement
           return data.map((item) => item as Map<String, dynamic>).toList();
         } else {
           debugPrint('Unexpected data type: ${data.runtimeType}');

--- a/lib/manage/widget_manage.dart
+++ b/lib/manage/widget_manage.dart
@@ -454,9 +454,7 @@ class AudioPlayerWidgetState extends State<AudioPlayerWidget>
                         ),
                         onPressed: () async {
                           widget.onToggleFavorite();
-                          // Toggle the notifier value which will trigger a rebuild
-                          bool liked = await MusicApiService().isLike(widget.songManager.getSongState()["songId"], authCookie!);
-                          _isLikedNotifier.value = liked;
+                          _isLikedNotifier.value = !_isLikedNotifier.value;
                         },
                       );
                     },

--- a/lib/screens/album_info_page.dart
+++ b/lib/screens/album_info_page.dart
@@ -76,10 +76,9 @@ class _AlbumInfoPageState extends State<AlbumInfoPage> {
     
     final tracks = _album_tracks!;
     final playlist = tracks.map<Map<String, dynamic>>((track) {
-      // Adapter selon la structure réelle des données retournées par l'API
       return {
         'title': track['SNG_TITLE'] ?? track['title'] ?? 'Unknown',
-        'song': 'http://192.168.1.53:8000/music/${track['SNG_ID']}.mp3',
+        'song': track['song'],
         'cover': _getAlbumCoverUrl(),
         'auteur': track['ART_NAME'] ?? track['artist'] ?? _album?['ART_NAME'] ?? _album?['artist'] ?? 'Unknown',
         'song_id': track['SNG_ID'] ?? track['song_id'] ?? track['id'] ?? '',
@@ -240,6 +239,7 @@ class _AlbumInfoPageState extends State<AlbumInfoPage> {
                                     itemCount: _album_tracks!.length,
                                     itemBuilder: (context, index) {
                                       final track = _album_tracks![index];
+                                      debugPrint('Track data: $track');
                                       return ListTile(
                                         leading: const Icon(Icons.music_note, color: Colors.white),
                                         title: Text(
@@ -251,7 +251,7 @@ class _AlbumInfoPageState extends State<AlbumInfoPage> {
                                           style: const TextStyle(color: Colors.white70),
                                         ),
                                         onTap: () => _playSong(
-                                          'http://192.168.1.53:8000/music/${track['SNG_ID']}.mp3',
+                                          track['song'],
                                           name: track['SNG_TITLE'] ?? track['title'] ?? 'Unknown',
                                           description: _album!["ALB_TITLE"] ?? _album!["title"] ?? '',
                                           pictureUrl: _getAlbumCoverUrl(),


### PR DESCRIPTION
This pull request refines how data is handled across several classes in the project, focusing on simplifying logic, improving data handling, and removing hardcoded values. Key changes include updates to `MusicApiService` for better API response parsing, adjustments to `AudioPlayerWidgetState` for toggling favorite state, and modifications in `_AlbumInfoPageState` to streamline track data usage.

### Improvements to API Response Parsing (`MusicApiService`):

* Removed redundant comments explaining data type checks for API responses to simplify the code. [[1]](diffhunk://#diff-1dda11da4bad4c6659996b8a0a46f7141d2f9c64e49741c014130d6482d631b7L386-L391) [[2]](diffhunk://#diff-1dda11da4bad4c6659996b8a0a46f7141d2f9c64e49741c014130d6482d631b7L402) [[3]](diffhunk://#diff-1dda11da4bad4c6659996b8a0a46f7141d2f9c64e49741c014130d6482d631b7L418)

### Updates to Favorite Toggle Logic (`AudioPlayerWidgetState`):

* Simplified the favorite toggle logic by directly inverting the `_isLikedNotifier` value instead of fetching the updated state from the API.

### Streamlining Track Data Handling (`_AlbumInfoPageState`):

* Replaced hardcoded song URLs with dynamic values from the `track['song']` field, ensuring flexibility and adaptability to API changes. [[1]](diffhunk://#diff-4a70159005a5c80e93b38edee0a6b93b5dcb06f02e5c7efd6a1dd22669906362L79-R81) [[2]](diffhunk://#diff-4a70159005a5c80e93b38edee0a6b93b5dcb06f02e5c7efd6a1dd22669906362L254-R254)
* Added debug logging to inspect track data during album page rendering, aiding in debugging and development.