### PR TITLE
[~]: Refactor application identifiers and update project description; add release script for key generation and app bundle build

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.deezer_app"
+    namespace = "com.epico"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -20,8 +20,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.deezer_app"
+        applicationId = "com.epico"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -31,11 +30,19 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            keyAlias = "epico"
+            keyPassword = System.getenv("KEY_PASSWORD") ?: ""
+            storeFile = file("epico_key.jks")
+            storePassword = System.getenv("STORE_PASSWORD") ?: ""
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            // Use the release signing config for release builds
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 }

--- a/android/app/src/main/kotlin/com/example/deezer_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/deezer_app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.deezer_app
+package com.epico
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.deezerApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.epico;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.deezerApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.epico.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.deezerApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.epico.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.deezerApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.epico.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.deezerApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.epico;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.deezerApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.epico;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: epico
-description: "A new Flutter project."
+description: "Epico is a music streaming application developed with Flutter for Epitech students."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+read -s -p "Entrez le mot de passe pour la clé : " KEY_PASS
+echo
+
+keytool -genkeypair -v \
+    -keystore epico_key.jks \
+    -keyalg RSA \
+    -keysize 2048 \
+    -validity 10000 \
+    -alias epico \
+    -storepass "$KEY_PASS" \
+    -keypass "$KEY_PASS" \
+    -dname "CN=epico, OU=epico, O=epico, L=Paris, S=IDF, C=FR"
+
+mv epico_key.jks android/app/epico_key.jks
+export KEY_PASSWORD="$KEY_PASS"
+export STORE_PASSWORD="$KEY_PASS"
+flutter build appbundle --release


### PR DESCRIPTION
This pull request updates the project to rebrand it from "Deezer App" to "Epico" and includes changes to the Android and iOS configurations, project metadata, and release process. The most important updates involve renaming package identifiers, updating signing configurations, and adding a script for generating release builds.

### Rebranding and Identification Updates:
* [`android/app/build.gradle.kts`](diffhunk://#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fbL9-R9): Changed `namespace` and `applicationId` to `com.epico` to reflect the new branding. [[1]](diffhunk://#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fbL9-R9) [[2]](diffhunk://#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fbL23-R23)
* [`android/app/src/main/kotlin/com/example/deezer_app/MainActivity.kt`](diffhunk://#diff-e89a116bbd1474c37b22b9b2b16b7dbf716fd0aa4dfb7013382f28028aa95dcaL1-R1): Updated the package declaration to `com.epico`.
* [`ios/Runner.xcodeproj/project.pbxproj`](diffhunk://#diff-413fd2395fd4377132c8c1135c9bc9ab215c6f97322d27717a487223bd03e2c7L371-R371): Updated `PRODUCT_BUNDLE_IDENTIFIER` to `com.epico` for the main app and test targets across multiple sections. [[1]](diffhunk://#diff-413fd2395fd4377132c8c1135c9bc9ab215c6f97322d27717a487223bd03e2c7L371-R371) [[2]](diffhunk://#diff-413fd2395fd4377132c8c1135c9bc9ab215c6f97322d27717a487223bd03e2c7L387-R387) [[3]](diffhunk://#diff-413fd2395fd4377132c8c1135c9bc9ab215c6f97322d27717a487223bd03e2c7L404-R404) [[4]](diffhunk://#diff-413fd2395fd4377132c8c1135c9bc9ab215c6f97322d27717a487223bd03e2c7L419-R419) [[5]](diffhunk://#diff-413fd2395fd4377132c8c1135c9bc9ab215c6f97322d27717a487223bd03e2c7L550-R550) [[6]](diffhunk://#diff-413fd2395fd4377132c8c1135c9bc9ab215c6f97322d27717a487223bd03e2c7L572-R572)

### Signing and Build Configuration:
* [`android/app/build.gradle.kts`](diffhunk://#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fbR33-R45): Added a release signing configuration using `epico_key.jks` and environment variables for passwords.
* [`release.sh`](diffhunk://#diff-8bc94a3006768345d17c827c0bb5840e6e4daee6de1c2b1ea672f53f162d171dR1-R19): Added a script to automate the generation of a signing key (`epico_key.jks`) and create a release build for the app.

### Project Metadata Updates:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R2): Updated the project name to `epico` and added a detailed description for the application.