### PR TITLE
[~]: Add similar song functionality to SongManager and UI integration

### DIFF
--- a/lib/manage/api_manage.dart
+++ b/lib/manage/api_manage.dart
@@ -439,4 +439,20 @@ class MusicApiService {
       throw Exception('Error fetching artist tracks: $e');
     }
   }
+
+  Future<Map<String, dynamic>> getSimilarSong(String songId) async {
+    try {
+      final response = await http.get(
+        Uri.parse('$baseUrl/music/similar/$songId'),
+      );
+      if (response.statusCode == 200) {
+        debugPrint('Response: ${response.body}');
+        return json.decode(response.body) as Map<String, dynamic>;
+      } else {
+        throw Exception('Failed to load similar song: ${response.statusCode}');
+      }
+    } catch (e) {
+      throw Exception('Error fetching similar song: $e');
+    }
+  }
 }

--- a/lib/manage/song_manage.dart
+++ b/lib/manage/song_manage.dart
@@ -97,7 +97,35 @@ class SongManager {
         instant: true,
       );
     } else {
-      debugPrint('No more songs in the queue.');
+      debugPrint('No more songs in the queue. Fetching similar song.');
+      if (_currentSongId != null) {
+        try {
+          final similarSong = await MusicApiService().getSimilarSong(_currentSongId!);
+        final insertIndex = _queue.isEmpty ? 0 : _queueIndex + 1;
+        _queue.insert(insertIndex, {
+          'name': similarSong['title'],
+          'description': '',
+          'songUrl': similarSong['song'],
+          'pictureUrl': similarSong['cover'],
+          'artist': similarSong['auteur'],
+          'songId': similarSong['song_id'],
+        });
+        _queueIndex = insertIndex;
+        await togglePlaySong(
+          name: _queue[_queueIndex]['name'],
+          description: _queue[_queueIndex]['description'],
+          songUrl: _queue[_queueIndex]['songUrl'],
+          pictureUrl: _queue[_queueIndex]['pictureUrl'],
+          artist: _queue[_queueIndex]['artist'],
+          songId: _queue[_queueIndex]['songId'],
+          instant: true,
+        );
+        } catch (e) {
+          debugPrint('Error fetching similar song: $e');
+        }
+      } else {
+        debugPrint('No current song ID to fetch similar songs.');
+      }
     }
   }
 

--- a/lib/manage/song_manage.dart
+++ b/lib/manage/song_manage.dart
@@ -145,6 +145,39 @@ class SongManager {
     );
   }
 
+  Future<void> similarSong() async {
+    if (_currentSongId == null) {
+      debugPrint('No current song to find a similar one.');
+      return;
+    }
+    try {
+      final similarSongData = await MusicApiService().getSimilarSong(_currentSongId!);
+      
+      final insertIndex = _queueIndex + 1;
+      _queue.insert(insertIndex, {
+        'name': similarSongData['title'],
+        'description': '',
+        'songUrl': similarSongData['song'],
+        'pictureUrl': similarSongData['cover'],
+        'artist': similarSongData['auteur'],
+        'songId': similarSongData['song_id'],
+      });
+      _queueIndex = insertIndex;
+
+      await togglePlaySong(
+        name: _queue[_queueIndex]['name'],
+        description: _queue[_queueIndex]['description'],
+        songUrl: _queue[_queueIndex]['songUrl'],
+        pictureUrl: _queue[_queueIndex]['pictureUrl'],
+        artist: _queue[_queueIndex]['artist'],
+        songId: _queue[_queueIndex]['songId'],
+        instant: true,
+      );
+    } catch (e) {
+      debugPrint('Error fetching or playing similar song: $e');
+    }
+  }
+
   Future<void> lunchPlaylist(List<Map<String, dynamic>> playlist) async {
     clearQueue();
     for (var element in playlist) {

--- a/lib/manage/widget_manage.dart
+++ b/lib/manage/widget_manage.dart
@@ -27,6 +27,7 @@ class AudioPlayerWidget extends StatefulWidget {
   final bool isFavorite;
   final VoidCallback onToggleFavorite;
   final VoidCallback onShare;
+  final VoidCallback onSimilar;
   final bool isPlaying;
   final String nextSongTitle;
   final String nextSongArtist;
@@ -44,6 +45,7 @@ class AudioPlayerWidget extends StatefulWidget {
     required this.isFavorite,
     required this.onToggleFavorite,
     required this.onShare,
+    required this.onSimilar,
     required this.isPlaying,
     required this.nextSongTitle,
     required this.nextSongArtist,
@@ -441,6 +443,10 @@ class AudioPlayerWidgetState extends State<AudioPlayerWidget>
                   IconButton(
                     icon: const Icon(Icons.share, color: Colors.white),
                     onPressed: widget.onShare,
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.shuffle, color: Colors.white),
+                    onPressed: widget.onSimilar,
                   ),
                 ],
               ),

--- a/lib/screens/album_info_page.dart
+++ b/lib/screens/album_info_page.dart
@@ -365,6 +365,9 @@ class _AlbumInfoPageState extends State<AlbumInfoPage> {
                         },
                         onToggleFavorite: () {},
                         onShare: () {},
+                        onSimilar: () {
+                          widget.songManager.similarSong();
+                        },
                         onNext: () {},
                         onPrevious: () {},
                       );

--- a/lib/screens/listen_page.dart
+++ b/lib/screens/listen_page.dart
@@ -316,6 +316,9 @@ class _MusicAppHomePageState extends State<MusicAppHomePage> {
                   onShare: () {
                     // Implement share functionality
                   },
+                  onSimilar: () {
+                    widget.songManager.similarSong();
+                  },
                   isPlaying: isPlaying,
                   nextSongTitle: 'Save Your Tears',
                   nextSongArtist: 'The Weeknd',


### PR DESCRIPTION
This pull request introduces a new feature that allows users to fetch and play similar songs when the current song ends or manually triggers the action. The changes span multiple files, adding functionality to the `MusicApiService`, enhancing the `SongManager`, and updating UI components to support the new feature.

### Backend Changes:

* **Added `getSimilarSong` method in `MusicApiService`:** This method fetches data for a similar song based on the provided song ID using an HTTP GET request. It returns the song details as a `Map<String, dynamic>`. (`lib/manage/api_manage.dart`, [lib/manage/api_manage.dartR442-R457](diffhunk://#diff-1dda11da4bad4c6659996b8a0a46f7141d2f9c64e49741c014130d6482d631b7R442-R457))

* **Enhanced `SongManager` to handle similar songs:**
  - Modified the song queue logic to automatically fetch and insert a similar song when the queue is empty. (`lib/manage/song_manage.dart`, [lib/manage/song_manage.dartL100-R128](diffhunk://#diff-f5dfed40c4eef8ccc19444bd7ac4ac41c4dffb6878c03857bfaa2805e8924764L100-R128))
  - Added a new `similarSong` method to fetch and play a similar song manually. (`lib/manage/song_manage.dart`, [lib/manage/song_manage.dartR148-R180](diffhunk://#diff-f5dfed40c4eef8ccc19444bd7ac4ac41c4dffb6878c03857bfaa2805e8924764R148-R180))

### UI Changes:

* **Updated `AudioPlayerWidget` to include a "Similar Song" button:**
  - Added a new `onSimilar` callback to the widget's constructor and state. (`lib/manage/widget_manage.dart`, [[1]](diffhunk://#diff-8e0ebbfe79babcea69794245fc69830a2b56e5eb791704d1fc690c7c1ace1c8bR30) [[2]](diffhunk://#diff-8e0ebbfe79babcea69794245fc69830a2b56e5eb791704d1fc690c7c1ace1c8bR48)
  - Added a shuffle icon button to trigger the `onSimilar` callback. (`lib/manage/widget_manage.dart`, [lib/manage/widget_manage.dartR447-R450](diffhunk://#diff-8e0ebbfe79babcea69794245fc69830a2b56e5eb791704d1fc690c7c1ace1c8bR447-R450))

* **Integrated "Similar Song" functionality into screens:**
  - Added the `onSimilar` callback to the `AlbumInfoPage` to allow fetching similar songs. (`lib/screens/album_info_page.dart`, [lib/screens/album_info_page.dartR368-R370](diffhunk://#diff-4a70159005a5c80e93b38edee0a6b93b5dcb06f02e5c7efd6a1dd22669906362R368-R370))
  - Added the `onSimilar` callback to the `MusicAppHomePage` for similar song functionality. (`lib/screens/listen_page.dart`, [lib/screens/listen_page.dartR319-R321](diffhunk://#diff-9c464ba3d00550455aad5dead920c6be2aa4971dfe2e0518de5d54c7ae8d478eR319-R321))