### PR TITLE
[~]: Remove unused share functionality from audio player and album info pages

### DIFF
--- a/lib/manage/widget_manage.dart
+++ b/lib/manage/widget_manage.dart
@@ -26,7 +26,6 @@ class AudioPlayerWidget extends StatefulWidget {
   final String lyricsExcerpt;
   final bool isFavorite;
   final VoidCallback onToggleFavorite;
-  final VoidCallback onShare;
   final VoidCallback onSimilar;
   final bool isPlaying;
   final String nextSongTitle;
@@ -44,7 +43,6 @@ class AudioPlayerWidget extends StatefulWidget {
     required this.lyricsExcerpt,
     required this.isFavorite,
     required this.onToggleFavorite,
-    required this.onShare,
     required this.onSimilar,
     required this.isPlaying,
     required this.nextSongTitle,
@@ -439,10 +437,6 @@ class AudioPlayerWidgetState extends State<AudioPlayerWidget>
                         },
                       );
                     },
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.share, color: Colors.white),
-                    onPressed: widget.onShare,
                   ),
                   IconButton(
                     icon: const Icon(Icons.shuffle, color: Colors.white),

--- a/lib/screens/album_info_page.dart
+++ b/lib/screens/album_info_page.dart
@@ -364,7 +364,6 @@ class _AlbumInfoPageState extends State<AlbumInfoPage> {
                           );
                         },
                         onToggleFavorite: () {},
-                        onShare: () {},
                         onSimilar: () {
                           widget.songManager.similarSong();
                         },

--- a/lib/screens/listen_page.dart
+++ b/lib/screens/listen_page.dart
@@ -313,9 +313,6 @@ class _MusicAppHomePageState extends State<MusicAppHomePage> {
                   onToggleFavorite: () {
                     MusicApiService().createLike(currentSongState['songId'] as String? ?? '', authCookie!);
                   },
-                  onShare: () {
-                    // Implement share functionality
-                  },
                   onSimilar: () {
                     widget.songManager.similarSong();
                   },


### PR DESCRIPTION
This pull request removes the functionality related to sharing songs from the `AudioPlayerWidget` and associated classes. The most important changes include removing the `onShare` callback property, its corresponding UI elements, and its usage in other parts of the codebase.

### Removal of song-sharing functionality:

* [`lib/manage/widget_manage.dart`](diffhunk://#diff-8e0ebbfe79babcea69794245fc69830a2b56e5eb791704d1fc690c7c1ace1c8bL29): Removed the `onShare` property from the `AudioPlayerWidget` class, its constructor, and the associated `IconButton` for sharing songs in the widget's UI. [[1]](diffhunk://#diff-8e0ebbfe79babcea69794245fc69830a2b56e5eb791704d1fc690c7c1ace1c8bL29) [[2]](diffhunk://#diff-8e0ebbfe79babcea69794245fc69830a2b56e5eb791704d1fc690c7c1ace1c8bL47) [[3]](diffhunk://#diff-8e0ebbfe79babcea69794245fc69830a2b56e5eb791704d1fc690c7c1ace1c8bL443-L446)
* [`lib/screens/album_info_page.dart`](diffhunk://#diff-4a70159005a5c80e93b38edee0a6b93b5dcb06f02e5c7efd6a1dd22669906362L367): Removed the `onShare` callback from the `_AlbumInfoPageState` class.
* [`lib/screens/listen_page.dart`](diffhunk://#diff-9c464ba3d00550455aad5dead920c6be2aa4971dfe2e0518de5d54c7ae8d478eL316-L318): Removed the `onShare` callback and its placeholder implementation from the `_MusicAppHomePageState` class.